### PR TITLE
Cache Evernote results after fetching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "name"          : "Evernote Duplicated - EVERDU",
   "description"   : "Chrome extension that checks whether you have this url in your notes or not",
   "version"       : "1.0.1",
+  "default_locale": "en",
   "browser_action": {
     "default_icon" : "images/Evernote-off.png",
     "default_title": "EVERDU - EVERnote DUplicated"


### PR DESCRIPTION
Hello,
I'm using your extension and find it quite useful, and yet I think it would benefit from caching results that were already fetched from Evernote.

With this approach, mostly useful with the 'all' workmode, all fetched urls results are cached in ram and reloaded on tab activation/reactivation.

There's some work to do on cache cleaning/expiration, but I'm sending you this before going too far, then we could discuss on how to go on.
